### PR TITLE
fix: handle empty CORS origins string correctly

### DIFF
--- a/src/voter_api/core/config.py
+++ b/src/voter_api/core/config.py
@@ -120,7 +120,9 @@ class Settings(BaseSettings):
     @property
     def cors_origin_list(self) -> list[str]:
         """Parse CORS origins string into a list."""
-        return [origin.strip() for origin in self.cors_origins.split(",")]
+        if not self.cors_origins.strip():
+            return []
+        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary

- Fix `cors_origin_list` property to return `[]` instead of `[""]` when `cors_origins` is empty
- Also filters out any blank entries in comma-separated origin lists
- Production `CORS_ORIGINS` has been set to `https://vote.kerryhatcher.com` via `piku config:set`

## Test plan

- [x] Existing `test_cors_origin_list` test passes
- [ ] Verify CORS headers present on production responses from `https://vote.kerryhatcher.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)