### PR TITLE
fix(deploy): restore piku ENV file to git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,6 @@ celerybeat.pid
 .venv
 env/
 venv/
-ENV
 ENV/
 env.bak/
 venv.bak/

--- a/ENV
+++ b/ENV
@@ -1,0 +1,43 @@
+# =============================================================================
+# Piku ENV Configuration for voter-api
+# =============================================================================
+# This file is deployed to the piku server. App-specific secrets should be
+# set via `piku config:set` on the server rather than committed here.
+
+# --- Piku / nginx settings ---
+NGINX_SERVER_NAME=voteapi.kerryhatcher.com
+NGINX_CLOUDFLARE_ACL=true
+BIND_ADDRESS=0.0.0.0
+
+# --- Required (set these via piku config:set for secrets) ---
+DATABASE_URL=postgresql+asyncpg://voter_api:CHANGE_ME@localhost:5432/voter_api
+JWT_SECRET_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32
+
+# --- JWT defaults ---
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# --- Geocoding ---
+GEOCODER_DEFAULT_PROVIDER=census
+GEOCODER_BATCH_SIZE=100
+GEOCODER_RATE_LIMIT_PER_SECOND=10
+
+# --- Import ---
+IMPORT_BATCH_SIZE=1000
+
+# --- Export ---
+EXPORT_DIR=./exports
+
+# --- Logging ---
+LOG_LEVEL=INFO
+
+# --- CORS ---
+CORS_ORIGINS=
+CORS_ORIGIN_REGEX=https://(.*\.voter-web\.pages\.dev|.*\.kerryhatcher\.com)
+
+# --- API ---
+API_V1_PREFIX=/api/v1
+
+# --- R2 / S3 (disabled by default) ---
+R2_ENABLED=false


### PR DESCRIPTION
## Summary

- Removes bare `ENV` from `.gitignore` (keeps `ENV/` for venv directories)
- Re-adds the piku `ENV` config file to git tracking

## Context

Commit `13b2542` (from PR #8) added `ENV` to `.gitignore` and removed it from tracking. When pushed to piku, this deleted the server's ENV file — breaking nginx config, CORS settings, and app configuration, causing **502 Bad Gateway** on production.

The `ENV` file contains only nginx/piku settings and placeholder secrets. Actual secrets (`DATABASE_URL`, `JWT_SECRET_KEY`) are set via `piku config:set` on the server.

## Test plan

- [x] No code changes — only `.gitignore` and file tracking
- [ ] After merge, `git push piku main` to deploy
- [ ] Verify API responds: `curl -I https://voteapi.kerryhatcher.com/api/v1/`
- [ ] Verify CORS headers present in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)