### PR TITLE
chore: migrate API domain to voteapi.civpulse.org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,8 @@ tests/
 
 ## Deployment (Piku)
 
-**Production URL**: `https://voteapi.kerryhatcher.com`
+**Production URL**: `https://voteapi.civpulse.org`
+**Legacy URL**: `https://voteapi.kerryhatcher.com` (still functional via CORS regex)
 
 The app deploys to a piku server (`hatchweb`) via `git push piku main`. Two git remotes are configured:
 
@@ -150,7 +151,7 @@ ssh piku@hatchweb.tailb56d83.ts.net -- config:set voter-api \
 
 External traffic reaches the app via a Cloudflare Tunnel (`hatchweb`), not direct port exposure:
 
-- **Domain**: `voteapi.kerryhatcher.com` (DNS managed by Cloudflare)
+- **Domains**: `voteapi.civpulse.org` (primary), `voteapi.kerryhatcher.com` (legacy) — both DNS managed by Cloudflare
 - **Tunnel route**: `HTTP://localhost:80` (Cloudflare terminates TLS at the edge)
 - Let's Encrypt certs are issued via ACME HTTP-01 through the tunnel. Piku also generates SSL listeners on port 443 — if another site on the server defines conflicting SSL protocol options (e.g. `ssl` vs `ssl http2`), piku's nginx config test will fail and delete the config. The hatchertechnology.com site was disabled to resolve this
 

--- a/ENV
+++ b/ENV
@@ -5,7 +5,7 @@
 # set via `piku config:set` on the server rather than committed here.
 
 # --- Piku / nginx settings ---
-NGINX_SERVER_NAME=voteapi.kerryhatcher.com
+NGINX_SERVER_NAME=voteapi.civpulse.org
 NGINX_CLOUDFLARE_ACL=true
 BIND_ADDRESS=0.0.0.0
 
@@ -34,7 +34,7 @@ LOG_LEVEL=INFO
 
 # --- CORS ---
 CORS_ORIGINS=
-CORS_ORIGIN_REGEX=https://(.*\.voter-web\.pages\.dev|.*\.kerryhatcher\.com)
+CORS_ORIGIN_REGEX=https://(.*\.voter-web\.pages\.dev|.*\.civpulse\.org|.*\.kerryhatcher\.com)
 
 # --- API ---
 API_V1_PREFIX=/api/v1


### PR DESCRIPTION
## Summary
Migrates the production API from `voteapi.kerryhatcher.com` to `voteapi.civpulse.org` while maintaining backward compatibility during the transition period.

## Changes
- **ENV**: Update `NGINX_SERVER_NAME` to `voteapi.civpulse.org`
- **ENV**: Add `.*\.civpulse\.org` to `CORS_ORIGIN_REGEX` (legacy domain retained)
- **CLAUDE.md**: Update production URL documentation
- **CLAUDE.md**: Mark `voteapi.kerryhatcher.com` as legacy URL

## Deployment Checklist

After merging, the following steps must be completed:

### 1. Cloudflare DNS Configuration
- [ ] Add CNAME record for `voteapi.civpulse.org` pointing to Cloudflare Tunnel

### 2. Cloudflare Tunnel Configuration
- [ ] Add public hostname `voteapi.civpulse.org` to the `hatchweb` tunnel
- [ ] Set service to `http://localhost:80`

### 3. Deploy to Production
- [ ] Run `git push piku main` to deploy updated ENV file

### 4. Verify
- [ ] Test new domain: `curl https://voteapi.civpulse.org/api/v1/health`
- [ ] Test legacy domain: `curl https://voteapi.kerryhatcher.com/api/v1/health`

## Notes
- Both domains will work during the transition
- CORS regex supports both `*.civpulse.org` and `*.kerryhatcher.com`
- Legacy domain can be removed in a future update once migration is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)