### PR TITLE
fix(officials): reduce Open States per_page to 50

### DIFF
--- a/src/voter_api/lib/officials/open_states.py
+++ b/src/voter_api/lib/officials/open_states.py
@@ -84,7 +84,7 @@ class OpenStatesProvider(BaseOfficialsProvider):
             "jurisdiction": "Georgia",
             "org_classification": org_classification,
             "include": "offices",
-            "per_page": 100,
+            "per_page": 50,
         }
         return await self._fetch_people(params)
 
@@ -154,15 +154,17 @@ class OpenStatesProvider(BaseOfficialsProvider):
             result: dict[str, Any] = response.json()
             return result
         except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
             logger.error(
-                "Open States API error: {} {} for {}",
+                "Open States API error: {} {} for {} — {}",
                 exc.response.status_code,
                 exc.response.reason_phrase,
                 path,
+                body,
             )
             raise OfficialsProviderError(
                 self.provider_name,
-                f"HTTP {exc.response.status_code}: {exc.response.reason_phrase}",
+                f"HTTP {exc.response.status_code}: {exc.response.reason_phrase} — {body}",
                 status_code=exc.response.status_code,
             ) from exc
         except httpx.RequestError as exc:


### PR DESCRIPTION
## Summary
- The Open States API now enforces a maximum `per_page` of 50, but `fetch_all_for_chamber` was requesting 100 — causing all state legislator syncs to fail with HTTP 400
- Reduced `per_page` from 100 to 50 (pagination already handles multi-page responses)
- Improved error logging to include the API response body for easier debugging of future API issues

## Test plan
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run pytest tests/unit/lib/test_officials/ -v` — 62 tests pass
- [x] `uv run voter-api officials sync --provider all` — both providers succeed (232 Open States + 15 Congress.gov records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)