### PR TITLE
fix(db): add missing migrations 020-022 from voter-history branch

### DIFF
--- a/alembic/versions/020_widen_voter_columns.py
+++ b/alembic/versions/020_widen_voter_columns.py
@@ -1,0 +1,33 @@
+"""widen voter columns to accommodate real GA SoS data
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-02-17
+
+Widens race (20→50), residence_street_number (20→50), and
+mailing_street_number (20→50) to fit actual GA Secretary of State
+voter file values (e.g. "ASIAN/PACIFIC ISLANDER" for race,
+long street numbers like "25" chars for addresses).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "020"
+down_revision: str | None = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("voters", "race", type_=sa.String(50), existing_type=sa.String(20))
+    op.alter_column("voters", "residence_street_number", type_=sa.String(50), existing_type=sa.String(20))
+    op.alter_column("voters", "mailing_street_number", type_=sa.String(50), existing_type=sa.String(20))
+
+
+def downgrade() -> None:
+    op.alter_column("voters", "race", type_=sa.String(20), existing_type=sa.String(50))
+    op.alter_column("voters", "residence_street_number", type_=sa.String(20), existing_type=sa.String(50))
+    op.alter_column("voters", "mailing_street_number", type_=sa.String(20), existing_type=sa.String(50))

--- a/alembic/versions/021_widen_more_voter_columns.py
+++ b/alembic/versions/021_widen_more_voter_columns.py
@@ -1,0 +1,30 @@
+"""widen additional voter columns for real GA SoS data
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-02-17
+
+Widens city_council_district (10→50) and mailing_zipcode (10→20)
+to handle real-world GA SoS voter file values. Houston County data
+contains values like "4-WARNER ROBINS" in city_council_district.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "021"
+down_revision: str | None = "020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("voters", "city_council_district", type_=sa.String(50), existing_type=sa.String(10))
+    op.alter_column("voters", "mailing_zipcode", type_=sa.String(20), existing_type=sa.String(10))
+
+
+def downgrade() -> None:
+    op.alter_column("voters", "city_council_district", type_=sa.String(10), existing_type=sa.String(50))
+    op.alter_column("voters", "mailing_zipcode", type_=sa.String(20), existing_type=sa.String(10))

--- a/alembic/versions/022_voter_history.py
+++ b/alembic/versions/022_voter_history.py
@@ -1,0 +1,97 @@
+"""create voter_history table, add elections.creation_method and import_jobs counters
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-02-17
+
+Creates voter_history table for GA SoS voter participation history records.
+Adds creation_method column to elections table to distinguish auto-created
+elections. Adds records_skipped and records_unmatched counters to import_jobs.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "022"
+down_revision: str | None = "021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- voter_history table ---
+    pg_uuid = sa.dialects.postgresql.UUID(as_uuid=True)
+    op.create_table(
+        "voter_history",
+        sa.Column(
+            "id",
+            pg_uuid,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("voter_registration_number", sa.String(20), nullable=False),
+        sa.Column("county", sa.String(100), nullable=False),
+        sa.Column("election_date", sa.Date, nullable=False),
+        sa.Column("election_type", sa.String(50), nullable=False),
+        sa.Column("normalized_election_type", sa.String(20), nullable=False),
+        sa.Column("party", sa.String(50), nullable=True),
+        sa.Column("ballot_style", sa.String(100), nullable=True),
+        sa.Column("absentee", sa.Boolean, nullable=False, server_default=sa.text("false")),
+        sa.Column("provisional", sa.Boolean, nullable=False, server_default=sa.text("false")),
+        sa.Column("supplemental", sa.Boolean, nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "import_job_id",
+            pg_uuid,
+            sa.ForeignKey("import_jobs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "voter_registration_number",
+            "election_date",
+            "election_type",
+            name="uq_voter_history_participation",
+        ),
+    )
+
+    # Indexes for voter_history
+    op.create_index("idx_voter_history_reg_num", "voter_history", ["voter_registration_number"])
+    op.create_index("idx_voter_history_election_date", "voter_history", ["election_date"])
+    op.create_index("idx_voter_history_election_type", "voter_history", ["election_type"])
+    op.create_index("idx_voter_history_county", "voter_history", ["county"])
+    op.create_index("idx_voter_history_import_job_id", "voter_history", ["import_job_id"])
+    op.create_index("idx_voter_history_date_type", "voter_history", ["election_date", "normalized_election_type"])
+
+    # --- elections.creation_method ---
+    op.add_column("elections", sa.Column("creation_method", sa.String(20), nullable=False, server_default="manual"))
+    op.create_index("idx_elections_creation_method", "elections", ["creation_method"])
+
+    # --- import_jobs new counters ---
+    op.add_column("import_jobs", sa.Column("records_skipped", sa.Integer, nullable=True))
+    op.add_column("import_jobs", sa.Column("records_unmatched", sa.Integer, nullable=True))
+
+
+def downgrade() -> None:
+    # import_jobs counters
+    op.drop_column("import_jobs", "records_unmatched")
+    op.drop_column("import_jobs", "records_skipped")
+
+    # elections.creation_method
+    op.drop_index("idx_elections_creation_method", table_name="elections")
+    op.drop_column("elections", "creation_method")
+
+    # voter_history table and indexes
+    op.drop_index("idx_voter_history_date_type", table_name="voter_history")
+    op.drop_index("idx_voter_history_import_job_id", table_name="voter_history")
+    op.drop_index("idx_voter_history_county", table_name="voter_history")
+    op.drop_index("idx_voter_history_election_type", table_name="voter_history")
+    op.drop_index("idx_voter_history_election_date", table_name="voter_history")
+    op.drop_index("idx_voter_history_reg_num", table_name="voter_history")
+    op.drop_table("voter_history")

--- a/src/voter_api/models/voter.py
+++ b/src/voter_api/models/voter.py
@@ -29,11 +29,11 @@ class Voter(Base, UUIDMixin, TimestampMixin):
 
     # Demographics
     birth_year: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    race: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    race: Mapped[str | None] = mapped_column(String(50), nullable=True)
     gender: Mapped[str | None] = mapped_column(String(10), nullable=True)
 
     # Residence address
-    residence_street_number: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    residence_street_number: Mapped[str | None] = mapped_column(String(50), nullable=True)
     residence_pre_direction: Mapped[str | None] = mapped_column(String(10), nullable=True)
     residence_street_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     residence_street_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
@@ -43,11 +43,11 @@ class Voter(Base, UUIDMixin, TimestampMixin):
     residence_zipcode: Mapped[str | None] = mapped_column(String(10), nullable=True, index=True)
 
     # Mailing address
-    mailing_street_number: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    mailing_street_number: Mapped[str | None] = mapped_column(String(50), nullable=True)
     mailing_street_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     mailing_apt_unit_number: Mapped[str | None] = mapped_column(String(20), nullable=True)
     mailing_city: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    mailing_zipcode: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    mailing_zipcode: Mapped[str | None] = mapped_column(String(20), nullable=True)
     mailing_state: Mapped[str | None] = mapped_column(String(50), nullable=True)
     mailing_country: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
@@ -62,7 +62,7 @@ class Voter(Base, UUIDMixin, TimestampMixin):
     judicial_district: Mapped[str | None] = mapped_column(String(10), nullable=True)
     county_commission_district: Mapped[str | None] = mapped_column(String(10), nullable=True)
     school_board_district: Mapped[str | None] = mapped_column(String(10), nullable=True)
-    city_council_district: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    city_council_district: Mapped[str | None] = mapped_column(String(50), nullable=True)
     municipal_school_board_district: Mapped[str | None] = mapped_column(String(10), nullable=True)
     water_board_district: Mapped[str | None] = mapped_column(String(10), nullable=True)
     super_council_district: Mapped[str | None] = mapped_column(String(10), nullable=True)


### PR DESCRIPTION
## Summary
- Cherry-picks migration files 020, 021, and 022 from the `006-voter-history` branch into `main` to fix the broken Alembic migration chain
- Updates Voter model column widths (`race`, `residence_street_number`, `mailing_street_number`, `city_council_district`, `mailing_zipcode`) to match the migrations
- Production DB was migrated to revision 021/022 via a direct piku push of `006-voter-history`, but those files were never merged to `main`, causing `CommandError: Can't locate revision identified by '021'` on every CI deploy

## Test plan
- [x] `uv run ruff check .` — zero violations
- [x] `uv run ruff format --check .` — all files formatted
- [x] `uv run pytest` — all 1079 tests pass
- [ ] After merge, verify production deploy workflow succeeds (Alembic `upgrade head` should be a no-op or apply 022)

🤖 Generated with [Claude Code](https://claude.com/claude-code)