### PR TITLE
fix(alembic): add missing VoterHistory model import to env.py

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -30,6 +30,7 @@ from voter_api.models.import_job import ImportJob  # noqa: F401
 from voter_api.models.precinct_metadata import PrecinctMetadata  # noqa: F401
 from voter_api.models.user import User  # noqa: F401
 from voter_api.models.voter import Voter  # noqa: F401
+from voter_api.models.voter_history import VoterHistory  # noqa: F401
 
 config = context.config
 


### PR DESCRIPTION
## Summary

- Add missing `VoterHistory` model import in `alembic/env.py` so it's registered with `Base.metadata`
- Without this import, `alembic revision --autogenerate` would not detect the `voter_history` table when generating future migrations
- All other models were already imported (lines 13-32); `VoterHistory` was missed when the voter-history feature was merged

## Test plan

- [ ] Verify `uv run ruff check alembic/env.py` passes
- [ ] Verify `uv run voter-api db upgrade` still runs cleanly
- [ ] Verify `alembic revision --autogenerate` correctly detects the `voter_history` table (no "new table" diff generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)