### PR TITLE
fix(ci): grant contents write permission to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
       issues: read
       id-token: write


### PR DESCRIPTION
## Summary
- Change `contents` permission from `read` to `write` in the Claude Code Action workflow so it can create branches and push commits when working on issues and PRs.

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Tag `@claude` on an issue or PR to confirm it can now push commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)