### PR TITLE
fix(cli): handle missing env vars in CLI callback for deploy-check

### DIFF
--- a/src/voter_api/cli/app.py
+++ b/src/voter_api/cli/app.py
@@ -1,6 +1,7 @@
 """Typer CLI root application with serve command."""
 
 import typer
+from pydantic import ValidationError
 
 from voter_api.core.config import get_settings
 from voter_api.core.logging import setup_logging
@@ -11,8 +12,13 @@ app = typer.Typer(name="voter-api", help="Georgia voter data management CLI")
 @app.callback()
 def _main_callback() -> None:
     """Initialize logging for all CLI commands."""
-    settings = get_settings()
-    setup_logging(settings.log_level, log_dir=settings.log_dir)
+    try:
+        settings = get_settings()
+        setup_logging(settings.log_level, log_dir=settings.log_dir)
+    except ValidationError:
+        # Commands like deploy-check don't need full settings;
+        # use default logging when required env vars are missing.
+        setup_logging("INFO")
 
 
 @app.command()


### PR DESCRIPTION
The Typer app callback unconditionally called get_settings(), which requires DATABASE_URL and JWT_SECRET_KEY. This caused deploy-check (a pure HTTP client) to fail in CI where those env vars aren't set.

Wrap get_settings() in try/except ValidationError so commands that don't need full settings fall back to default INFO-level logging.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CLI startup reliability by implementing fallback logging when required environment variables are missing, preventing complete initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->