### PR TITLE
fix: recover stale analysis runs on server startup

### DIFF
--- a/src/voter_api/main.py
+++ b/src/voter_api/main.py
@@ -60,7 +60,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     init_engine(settings.database_url, echo=False, schema=settings.database_schema)
 
     # Recover analysis runs orphaned by a previous server restart
-    await _recover_stale_analysis_runs()
+    try:
+        await _recover_stale_analysis_runs()
+    except Exception:
+        logger.warning("Could not recover stale analysis runs on startup (table may not exist yet)")
 
     # Start election auto-refresh background task
     refresh_task = None

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -126,3 +126,36 @@ class TestAppLifespan:
                 mock_recover.assert_awaited_once()
 
             mock_dispose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_continues_when_recovery_fails(self) -> None:
+        """Lifespan proceeds normally even if stale-run recovery raises."""
+        from voter_api.core.config import Settings
+        from voter_api.main import lifespan
+
+        mock_app = AsyncMock()
+
+        with (
+            patch("voter_api.main.get_settings") as mock_get_settings,
+            patch("voter_api.main.setup_logging"),
+            patch("voter_api.main.init_engine"),
+            patch("voter_api.main.dispose_engine", new_callable=AsyncMock) as mock_dispose,
+            patch(
+                "voter_api.main._recover_stale_analysis_runs",
+                new_callable=AsyncMock,
+                side_effect=Exception("relation does not exist"),
+            ),
+            patch("voter_api.main.logger") as mock_logger,
+        ):
+            mock_get_settings.return_value = Settings(
+                database_url="sqlite+aiosqlite:///:memory:",
+                jwt_secret_key="test-secret-key-not-for-production",
+            )
+
+            async with lifespan(mock_app):
+                pass  # App should start successfully
+
+            mock_dispose.assert_awaited_once()
+            mock_logger.warning.assert_called_once_with(
+                "Could not recover stale analysis runs on startup (table may not exist yet)"
+            )


### PR DESCRIPTION
## Summary
- Analysis runs using in-process `asyncio.create_task()` don't survive server restarts, leaving DB rows stuck in `running`/`pending` status forever
- Adds `_recover_stale_analysis_runs()` to the app lifespan startup that bulk-updates orphaned runs to `failed`
- Logs a warning with the count of recovered runs

## Test plan
- [x] Unit tests for recovery function (stale runs found / no stale runs)
- [x] Lifespan test updated to verify recovery is called on startup
- [ ] Deploy to dev and verify stale runs are marked as failed in logs
- [ ] Trigger a new analysis run to confirm normal flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On startup, analysis runs stuck in running or pending states are now marked failed, appended with a restart note (preserving existing notes) and timestamped; a warning is logged when recoveries occur or if recovery cannot run.

* **Tests**
  * Added tests for startup recovery behavior, including successful recoveries and graceful handling/logging when recovery fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->