### PR TITLE
fix(elections): add district-scoped filter to election participation fallback

### DIFF
--- a/src/voter_api/services/voter_history_service.py
+++ b/src/voter_api/services/voter_history_service.py
@@ -895,11 +895,13 @@ async def _build_election_match_conditions(
     matches by (date, normalized_election_type) for disambiguation.
 
     County scoping: when the election is county-scoped (district_type ==
-    "county" and district_identifier is set), an additional predicate
-    ``VoterHistory.county == district_identifier`` is appended to whichever
-    branch applies (both unresolved and the fallback clause inside the
-    resolved OR). This prevents cross-county leakage when county elections
-    share a date with other county elections.
+    "county", or district_type is None but boundary is a county boundary),
+    an additional county-name predicate is appended to whichever branch
+    applies (both unresolved and the fallback clause inside the resolved OR).
+    The predicate compares ``UPPER(VoterHistory.county)`` to the county name
+    derived from ``election.boundary.name`` (stripping the " County" suffix).
+    This prevents cross-county leakage when county elections share a date
+    with other county elections.
 
     Args:
         session: Database session.
@@ -911,9 +913,15 @@ async def _build_election_match_conditions(
 
     def _build_district_filter() -> ColumnElement[bool] | None:
         """Return a county filter if election is county-scoped, else None."""
-        if election.district_type == "county" and election.district_identifier:
-            return VoterHistory.county == election.district_identifier
-        return None
+        is_county_scoped = election.district_type == "county" or (
+            election.district_type is None
+            and election.boundary is not None
+            and getattr(election.boundary, "boundary_type", None) == "county"
+        )
+        if not is_county_scoped or election.boundary is None or not election.boundary.name:
+            return None
+        county_name = election.boundary.name.removesuffix(" County")
+        return func.upper(VoterHistory.county) == county_name.upper()
 
     # Check if any voter_history records have been resolved for this election
     has_resolved = await session.execute(select(exists().where(VoterHistory.election_id == election.id)))

--- a/tests/unit/test_services/test_voter_history_service.py
+++ b/tests/unit/test_services/test_voter_history_service.py
@@ -686,9 +686,13 @@ class TestBuildElectionMatchConditions:
 
     async def test_county_election_unresolved_single_date_adds_county_predicate(self) -> None:
         """County-scoped election appends county predicate (unresolved path, single election on date)."""
+        boundary = MagicMock()
+        boundary.name = "Fulton County"
+        boundary.boundary_type = "county"
         election = _mock_election(
             district_type="county",
-            district_identifier="FULTON",
+            district_identifier="13121",
+            boundary=boundary,
         )
         session = AsyncMock()
         resolved_count_result = MagicMock()
@@ -701,12 +705,20 @@ class TestBuildElectionMatchConditions:
 
         # date condition + county condition (no type condition since single election)
         assert len(conditions) == 2
+        # County predicate must use UPPER(county) name comparison, not raw GEOID
+        county_sql = str(conditions[1])
+        assert "upper(voter_history.county)" in county_sql.lower()
+        assert "13121" not in county_sql
 
     async def test_county_election_unresolved_multi_date_adds_county_predicate(self) -> None:
         """County-scoped election appends county predicate (unresolved path, multiple elections on date)."""
+        boundary = MagicMock()
+        boundary.name = "Fulton County"
+        boundary.boundary_type = "county"
         election = _mock_election(
             district_type="county",
-            district_identifier="FULTON",
+            district_identifier="13121",
+            boundary=boundary,
             election_type="primary",
         )
         session = AsyncMock()
@@ -720,12 +732,19 @@ class TestBuildElectionMatchConditions:
 
         # date + type + county conditions
         assert len(conditions) == 3
+        county_sql = str(conditions[2])
+        assert "upper(voter_history.county)" in county_sql.lower()
+        assert "13121" not in county_sql
 
     async def test_county_election_resolved_single_date_includes_county_in_fallback(self) -> None:
         """County predicate is inside the unresolved fallback OR clause (resolved path, single date)."""
+        boundary = MagicMock()
+        boundary.name = "Fulton County"
+        boundary.boundary_type = "county"
         election = _mock_election(
             district_type="county",
-            district_identifier="FULTON",
+            district_identifier="13121",
+            boundary=boundary,
         )
         session = AsyncMock()
         resolved_count_result = MagicMock()
@@ -738,14 +757,19 @@ class TestBuildElectionMatchConditions:
 
         # Single OR condition wrapping (election_id match OR fallback-with-county)
         assert len(conditions) == 1
-        # County predicate must appear in the compiled SQL
-        assert "county" in str(conditions[0]).lower()
+        or_sql = str(conditions[0])
+        assert "upper(voter_history.county)" in or_sql.lower()
+        assert "13121" not in or_sql
 
     async def test_county_election_resolved_multi_date_includes_county_in_fallback(self) -> None:
         """County predicate is inside the unresolved fallback OR clause (resolved path, multi date)."""
+        boundary = MagicMock()
+        boundary.name = "Fulton County"
+        boundary.boundary_type = "county"
         election = _mock_election(
             district_type="county",
-            district_identifier="FULTON",
+            district_identifier="13121",
+            boundary=boundary,
             election_type="primary",
         )
         session = AsyncMock()
@@ -758,7 +782,32 @@ class TestBuildElectionMatchConditions:
         conditions = await _build_election_match_conditions(session, election)
 
         assert len(conditions) == 1
-        assert "county" in str(conditions[0]).lower()
+        or_sql = str(conditions[0])
+        assert "upper(voter_history.county)" in or_sql.lower()
+        assert "13121" not in or_sql
+
+    async def test_manual_county_election_unresolved_single_date_adds_county_predicate(self) -> None:
+        """Manual county election (null district fields, county boundary) appends county predicate."""
+        boundary = MagicMock()
+        boundary.name = "Bibb County"
+        boundary.boundary_type = "county"
+        election = _mock_election(
+            district_type=None,
+            district_identifier=None,
+            boundary=boundary,
+        )
+        session = AsyncMock()
+        resolved_count_result = MagicMock()
+        resolved_count_result.scalar_one.return_value = 0
+        date_count_result = MagicMock()
+        date_count_result.scalar_one.return_value = 1
+        session.execute = AsyncMock(side_effect=[resolved_count_result, date_count_result])
+
+        conditions = await _build_election_match_conditions(session, election)
+
+        # date condition + county condition
+        assert len(conditions) == 2
+        assert any("upper(voter_history.county)" in str(c).lower() for c in conditions)
 
     async def test_participants_with_type_mismatch_single_election(self) -> None:
         """Type="special" election finds voter_history with normalized_type="runoff" via date-only match."""


### PR DESCRIPTION
## Summary

- Fixes cross-election data leak in `GET /elections/{election_id}/participation` where county-scoped elections were returning voter history records from other counties
- Adds a `_build_district_filter()` helper in `_build_election_match_conditions()` that scopes fallback date-based matching to `VoterHistory.county` when the election has `district_type="county"` and a non-null `district_identifier`
- Applied to all four fallback paths (has_resolved/not × single-date/multi-date)

## Root Cause

The fallback heuristic matched unresolved `voter_history` rows by `(election_date, normalized_election_type)` only — no county filter. When multiple county elections share the same date (e.g., Bibb County general + Fulton County general on 2024-11-05), all unresolved rows from every county matched each election, leaking cross-county participation data.

## Test plan

- [ ] All existing participation/voter_history tests pass (`166 passed`)
- [ ] Lint clean (`ruff check` + `ruff format --check`)
- [ ] Verify against prod: `GET /api/v1/elections/90d226b5-94c7-4c22-b66f-35ea1c78ee8a/participation` — all returned voters should have `county == "Bibb"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Voter record matching now respects county-scoped filters for county elections, preventing cross-county leakage and ensuring queries are constrained to the correct county across resolved/unresolved and single/multi-date scenarios.
* **Tests**
  * Added unit tests validating county-scoped election matching across resolved vs unresolved paths and single vs multiple election-date situations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->