### PR TITLE
feat: manual election results submission endpoint

### DIFF
--- a/src/voter_api/api/v1/elections.py
+++ b/src/voter_api/api/v1/elections.py
@@ -36,6 +36,7 @@ from voter_api.schemas.election import (
     FeedImportRequest,
     FeedImportResponse,
     FilterOptionsResponse,
+    ManualResultSubmitRequest,
     PaginatedElectionListResponse,
     RawElectionResultsResponse,
     RefreshResponse,
@@ -299,6 +300,35 @@ async def link_election(
     if election is None:
         raise HTTPException(status_code=404, detail="Election not found.")
     return election_service.build_detail_response(election)
+
+
+# --- Manual result submission ---
+
+
+@elections_router.post(
+    "/{election_id}/results",
+    response_model=ElectionResultsResponse,
+    status_code=201,
+    responses={
+        404: {"description": "Election not found"},
+        409: {"description": "Cannot submit manual results for SOS feed election"},
+    },
+)
+async def submit_election_results(
+    election_id: uuid.UUID,
+    request: ManualResultSubmitRequest,
+    session: Annotated[AsyncSession, Depends(get_async_session)],
+    _current_user: Annotated[User, Depends(require_role("admin"))],
+) -> ElectionResultsResponse:
+    """Submit manual election results for a non-SOS-feed election. Admin-only."""
+    try:
+        result = await election_service.submit_manual_results(session, election_id, request)
+    except ValueError as e:
+        detail = str(e)
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from e
+        raise HTTPException(status_code=409, detail=detail) from e
+    return result
 
 
 # --- US1: JSON results ---

--- a/src/voter_api/api/v1/elections.py
+++ b/src/voter_api/api/v1/elections.py
@@ -42,7 +42,12 @@ from voter_api.schemas.election import (
     RefreshResponse,
 )
 from voter_api.services import election_service
-from voter_api.services.election_service import DuplicateElectionError, soft_delete_election
+from voter_api.services.election_service import (
+    DuplicateElectionError,
+    ElectionNotFoundError,
+    ManualResultConflictError,
+    soft_delete_election,
+)
 
 elections_router = APIRouter(prefix="/elections", tags=["elections"])
 
@@ -308,26 +313,28 @@ async def link_election(
 @elections_router.post(
     "/{election_id}/results",
     response_model=ElectionResultsResponse,
-    status_code=201,
     responses={
+        200: {"description": "Results updated (upsert)"},
+        201: {"description": "Results created"},
         404: {"description": "Election not found"},
-        409: {"description": "Cannot submit manual results for SOS feed election"},
+        409: {"description": "Cannot submit manual results for non-manual election"},
     },
 )
 async def submit_election_results(
     election_id: uuid.UUID,
     request: ManualResultSubmitRequest,
+    response: Response,
     session: Annotated[AsyncSession, Depends(get_async_session)],
     _current_user: Annotated[User, Depends(require_role("admin"))],
 ) -> ElectionResultsResponse:
-    """Submit manual election results for a non-SOS-feed election. Admin-only."""
+    """Submit manual election results for a manual-source election. Admin-only."""
     try:
-        result = await election_service.submit_manual_results(session, election_id, request)
-    except ValueError as e:
-        detail = str(e)
-        if "not found" in detail.lower():
-            raise HTTPException(status_code=404, detail=detail) from e
-        raise HTTPException(status_code=409, detail=detail) from e
+        result, is_update = await election_service.submit_manual_results(session, election_id, request)
+    except ElectionNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ManualResultConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    response.status_code = 200 if is_update else 201
     return result
 
 

--- a/src/voter_api/schemas/election.py
+++ b/src/voter_api/schemas/election.py
@@ -82,6 +82,31 @@ class ElectionLinkRequest(BaseModel):
     ballot_item_id: str | None = Field(default=None, min_length=1, max_length=50)
 
 
+class ManualVoteMethodResult(BaseModel):
+    """Vote method breakdown for manual result submission."""
+
+    group_name: str
+    vote_count: int = Field(ge=0)
+
+
+class ManualCandidateResult(BaseModel):
+    """Candidate result for manual result submission."""
+
+    name: str
+    political_party: str = ""
+    ballot_order: int = 1
+    vote_count: int = Field(ge=0)
+    group_results: list[ManualVoteMethodResult] = Field(default_factory=list)
+
+
+class ManualResultSubmitRequest(BaseModel):
+    """Request body for submitting manual election results."""
+
+    precincts_participating: int | None = None
+    precincts_reporting: int | None = None
+    candidates: list[ManualCandidateResult] = Field(min_length=1)
+
+
 # --- Response schemas ---
 
 

--- a/src/voter_api/schemas/election.py
+++ b/src/voter_api/schemas/election.py
@@ -5,7 +5,7 @@ Request/response models per contracts/openapi.yaml.
 
 import uuid
 from datetime import date, datetime
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel, Field, HttpUrl, computed_field, model_validator
 
@@ -85,26 +85,36 @@ class ElectionLinkRequest(BaseModel):
 class ManualVoteMethodResult(BaseModel):
     """Vote method breakdown for manual result submission."""
 
-    group_name: str
+    group_name: str = Field(min_length=1, max_length=100)
     vote_count: int = Field(ge=0)
 
 
 class ManualCandidateResult(BaseModel):
     """Candidate result for manual result submission."""
 
-    name: str
-    political_party: str = ""
-    ballot_order: int = 1
+    name: str = Field(min_length=1, max_length=200)
+    political_party: str = Field(default="", max_length=100)
+    ballot_order: int = Field(ge=1)
     vote_count: int = Field(ge=0)
-    group_results: list[ManualVoteMethodResult] = Field(default_factory=list)
+    group_results: list[ManualVoteMethodResult] = Field(default_factory=list, max_length=20)
 
 
 class ManualResultSubmitRequest(BaseModel):
     """Request body for submitting manual election results."""
 
-    precincts_participating: int | None = None
-    precincts_reporting: int | None = None
-    candidates: list[ManualCandidateResult] = Field(min_length=1)
+    precincts_participating: int | None = Field(default=None, ge=0)
+    precincts_reporting: int | None = Field(default=None, ge=0)
+    candidates: list[ManualCandidateResult] = Field(min_length=1, max_length=100)
+
+    @model_validator(mode="after")
+    def _check_precincts(self) -> Self:
+        if (
+            self.precincts_participating is not None
+            and self.precincts_reporting is not None
+            and self.precincts_reporting > self.precincts_participating
+        ):
+            raise ValueError("precincts_reporting cannot exceed precincts_participating")
+        return self
 
 
 # --- Response schemas ---

--- a/src/voter_api/services/election_service.py
+++ b/src/voter_api/services/election_service.py
@@ -44,6 +44,7 @@ from voter_api.schemas.election import (
     FeedImportRequest,
     FeedImportResponse,
     FeedRaceSummary,
+    ManualResultSubmitRequest,
     PrecinctCandidateResult,
     PrecinctElectionResultFeature,
     PrecinctElectionResultFeatureCollection,
@@ -527,6 +528,78 @@ async def get_raw_election_results(
         statewide_results=statewide_results,
         county_results=county_results,
     )
+
+
+async def submit_manual_results(
+    session: AsyncSession,
+    election_id: uuid.UUID,
+    request: ManualResultSubmitRequest,
+) -> ElectionResultsResponse:
+    """Submit manual election results for a non-SOS-feed election.
+
+    Args:
+        session: Async database session.
+        election_id: The election UUID.
+        request: Manual result submission data.
+
+    Returns:
+        ElectionResultsResponse with the submitted results.
+
+    Raises:
+        ValueError: If election not found or source is sos_feed.
+    """
+    election = await get_election_by_id(session, election_id)
+    if election is None:
+        msg = "Election not found."
+        raise ValueError(msg)
+
+    if election.source == "sos_feed":
+        msg = "Cannot submit manual results for an SOS feed election. Use the refresh endpoint instead."
+        raise ValueError(msg)
+
+    # Build JSONB results in the same format used by SOS feed ingestion
+    results_data: list[dict] = []
+    for candidate in request.candidates:
+        slug = candidate.name.lower().replace(" ", "-").replace(".", "")
+        results_data.append(
+            {
+                "id": slug,
+                "name": candidate.name,
+                "politicalParty": candidate.political_party,
+                "ballotOrder": candidate.ballot_order,
+                "voteCount": candidate.vote_count,
+                "groupResults": [
+                    {"groupName": gr.group_name, "voteCount": gr.vote_count} for gr in candidate.group_results
+                ],
+            }
+        )
+
+    now = datetime.now(UTC)
+
+    # Upsert statewide result
+    existing_result = await session.execute(select(ElectionResult).where(ElectionResult.election_id == election_id))
+    result_row = existing_result.scalar_one_or_none()
+
+    if result_row is None:
+        result_row = ElectionResult(
+            election_id=election_id,
+            precincts_participating=request.precincts_participating,
+            precincts_reporting=request.precincts_reporting,
+            results_data=results_data,
+            fetched_at=now,
+        )
+        session.add(result_row)
+    else:
+        result_row.precincts_participating = request.precincts_participating
+        result_row.precincts_reporting = request.precincts_reporting
+        result_row.results_data = results_data
+        result_row.fetched_at = now
+
+    election.last_refreshed_at = now
+    await session.commit()
+
+    # Return via existing response builder
+    return await get_election_results(session, election_id)
 
 
 async def persist_ingestion_result(

--- a/src/voter_api/services/election_service.py
+++ b/src/voter_api/services/election_service.py
@@ -544,7 +544,7 @@ async def submit_manual_results(
     session: AsyncSession,
     election_id: uuid.UUID,
     request: ManualResultSubmitRequest,
-) -> ElectionResultsResponse:
+) -> tuple[ElectionResultsResponse, bool]:
     """Submit manual election results for a non-SOS-feed election.
 
     Args:

--- a/src/voter_api/services/election_service.py
+++ b/src/voter_api/services/election_service.py
@@ -4,12 +4,14 @@ Orchestrates election CRUD, result fetching, and data assembly.
 """
 
 import asyncio
+import re
 import uuid
 from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from sqlalchemy import and_, func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -136,6 +138,14 @@ async def get_filter_options(session: AsyncSession) -> dict:
 
 class DuplicateElectionError(ValueError):
     """Raised when attempting to create an election that already exists."""
+
+
+class ManualResultConflictError(ValueError):
+    """Raised when manual results cannot be submitted for a non-manual election."""
+
+
+class ElectionNotFoundError(ValueError):
+    """Raised when an election is not found."""
 
 
 def _ballot_option_to_candidate(opt: dict) -> CandidateResult:
@@ -546,24 +556,24 @@ async def submit_manual_results(
         ElectionResultsResponse with the submitted results.
 
     Raises:
-        ValueError: If election not found or source is sos_feed.
+        ElectionNotFoundError: If election not found.
+        ManualResultConflictError: If election source is not manual.
     """
     election = await get_election_by_id(session, election_id)
     if election is None:
-        msg = "Election not found."
-        raise ValueError(msg)
+        raise ElectionNotFoundError("Election not found.")
 
-    if election.source == "sos_feed":
-        msg = "Cannot submit manual results for an SOS feed election. Use the refresh endpoint instead."
-        raise ValueError(msg)
+    if election.source != "manual":
+        raise ManualResultConflictError(f"Cannot submit manual results for a '{election.source}' election.")
 
     # Build JSONB results in the same format used by SOS feed ingestion
     results_data: list[dict] = []
     for candidate in request.candidates:
-        slug = candidate.name.lower().replace(" ", "-").replace(".", "")
+        slug = re.sub(r"[^a-z0-9]+", "-", candidate.name.lower()).strip("-")
+        candidate_id = f"{slug}-{candidate.ballot_order}"
         results_data.append(
             {
-                "id": slug,
+                "id": candidate_id,
                 "name": candidate.name,
                 "politicalParty": candidate.political_party,
                 "ballotOrder": candidate.ballot_order,
@@ -576,9 +586,12 @@ async def submit_manual_results(
 
     now = datetime.now(UTC)
 
-    # Upsert statewide result
-    existing_result = await session.execute(select(ElectionResult).where(ElectionResult.election_id == election_id))
+    # Upsert statewide result with SELECT ... FOR UPDATE to prevent race conditions
+    existing_result = await session.execute(
+        select(ElectionResult).where(ElectionResult.election_id == election_id).with_for_update()
+    )
     result_row = existing_result.scalar_one_or_none()
+    is_update = result_row is not None
 
     if result_row is None:
         result_row = ElectionResult(
@@ -596,10 +609,26 @@ async def submit_manual_results(
         result_row.fetched_at = now
 
     election.last_refreshed_at = now
-    await session.commit()
 
-    # Return via existing response builder
-    return await get_election_results(session, election_id)
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise ManualResultConflictError("Concurrent result submission detected. Please retry.") from exc
+
+    # Build response directly from in-memory data to avoid redundant DB round-trip
+    candidates = [_ballot_option_to_candidate(opt) for opt in results_data]
+    return ElectionResultsResponse(
+        election_id=election.id,
+        election_name=election.name,
+        election_date=election.election_date,
+        status=election.status,
+        last_refreshed_at=now,
+        precincts_participating=request.precincts_participating,
+        precincts_reporting=request.precincts_reporting,
+        candidates=candidates,
+        county_results=[],
+    ), is_update
 
 
 async def persist_ingestion_result(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -714,8 +714,15 @@ class TestElections:
                 await db_session.execute(delete(Election).where(Election.id == uuid.UUID(election_id)))
                 await db_session.commit()
 
-    async def test_submit_manual_results(self, admin_client: httpx.AsyncClient) -> None:
-        """Submit manual results to a manual-source election and verify via GET."""
+    async def test_submit_manual_results(
+        self,
+        admin_client: httpx.AsyncClient,
+        client: httpx.AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """Submit manual results to a manual-source election, verify via GET, then clean up."""
+        from voter_api.models.election import ElectionResult
+
         payload = {
             "precincts_participating": 6,
             "precincts_reporting": 6,
@@ -737,22 +744,78 @@ class TestElections:
             ],
         }
         # ELECTION_LOCAL_ID is source=manual
-        submit_resp = await admin_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
-        assert submit_resp.status_code == 201
-        body = submit_resp.json()
-        assert body["precincts_reporting"] == 6
-        assert body["precincts_participating"] == 6
-        assert len(body["candidates"]) == 2
-        assert body["candidates"][0]["name"] == "Test Candidate A"
-        assert body["candidates"][0]["vote_count"] == 100
+        try:
+            submit_resp = await admin_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
+            assert submit_resp.status_code == 201
+            body = submit_resp.json()
+            assert body["precincts_reporting"] == 6
+            assert body["precincts_participating"] == 6
+            assert len(body["candidates"]) == 2
+            assert body["candidates"][0]["name"] == "Test Candidate A"
+            assert body["candidates"][0]["vote_count"] == 100
+
+            # Verify round-trip via GET
+            get_resp = await client.get(_url(f"/elections/{ELECTION_LOCAL_ID}/results"))
+            assert get_resp.status_code == 200
+            get_body = get_resp.json()
+            assert get_body["precincts_reporting"] == 6
+            assert len(get_body["candidates"]) == 2
+        finally:
+            # Clean up the ElectionResult row
+            await db_session.execute(delete(ElectionResult).where(ElectionResult.election_id == ELECTION_LOCAL_ID))
+            await db_session.commit()
+
+    async def test_submit_manual_results_idempotent(
+        self,
+        admin_client: httpx.AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        """Submitting results twice replaces (not appends) and returns 200 on update."""
+        from voter_api.models.election import ElectionResult
+
+        payload = {
+            "precincts_participating": 6,
+            "precincts_reporting": 6,
+            "candidates": [
+                {"name": "Candidate A", "ballot_order": 1, "vote_count": 100},
+            ],
+        }
+        try:
+            first = await admin_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
+            assert first.status_code == 201
+
+            # Second submit with updated data
+            payload["candidates"][0]["vote_count"] = 200
+            second = await admin_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
+            assert second.status_code == 200
+            assert second.json()["candidates"][0]["vote_count"] == 200
+        finally:
+            await db_session.execute(delete(ElectionResult).where(ElectionResult.election_id == ELECTION_LOCAL_ID))
+            await db_session.commit()
 
     async def test_submit_manual_results_sos_feed_409(self, admin_client: httpx.AsyncClient) -> None:
         """Submitting results to an SOS feed election returns 409."""
         payload = {
-            "candidates": [{"name": "Test", "vote_count": 1}],
+            "candidates": [{"name": "Test", "ballot_order": 1, "vote_count": 1}],
         }
         resp = await admin_client.post(_url(f"/elections/{ELECTION_ID}/results"), json=payload)
         assert resp.status_code == 409
+
+    async def test_submit_manual_results_viewer_403(self, viewer_client: httpx.AsyncClient) -> None:
+        """Viewer cannot submit manual results."""
+        payload = {
+            "candidates": [{"name": "Test", "ballot_order": 1, "vote_count": 1}],
+        }
+        resp = await viewer_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
+        assert resp.status_code == 403
+
+    async def test_submit_manual_results_analyst_403(self, analyst_client: httpx.AsyncClient) -> None:
+        """Analyst cannot submit manual results."""
+        payload = {
+            "candidates": [{"name": "Test", "ballot_order": 1, "vote_count": 1}],
+        }
+        resp = await analyst_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
+        assert resp.status_code == 403
 
     async def test_get_election_results_empty(self, client: httpx.AsyncClient) -> None:
         """Results endpoint returns 200 with empty data when no results ingested yet."""

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -714,6 +714,46 @@ class TestElections:
                 await db_session.execute(delete(Election).where(Election.id == uuid.UUID(election_id)))
                 await db_session.commit()
 
+    async def test_submit_manual_results(self, admin_client: httpx.AsyncClient) -> None:
+        """Submit manual results to a manual-source election and verify via GET."""
+        payload = {
+            "precincts_participating": 6,
+            "precincts_reporting": 6,
+            "candidates": [
+                {
+                    "name": "Test Candidate A",
+                    "ballot_order": 1,
+                    "vote_count": 100,
+                    "group_results": [
+                        {"group_name": "Election Day", "vote_count": 60},
+                        {"group_name": "Advance Voting", "vote_count": 40},
+                    ],
+                },
+                {
+                    "name": "Test Candidate B",
+                    "ballot_order": 2,
+                    "vote_count": 50,
+                },
+            ],
+        }
+        # ELECTION_LOCAL_ID is source=manual
+        submit_resp = await admin_client.post(_url(f"/elections/{ELECTION_LOCAL_ID}/results"), json=payload)
+        assert submit_resp.status_code == 201
+        body = submit_resp.json()
+        assert body["precincts_reporting"] == 6
+        assert body["precincts_participating"] == 6
+        assert len(body["candidates"]) == 2
+        assert body["candidates"][0]["name"] == "Test Candidate A"
+        assert body["candidates"][0]["vote_count"] == 100
+
+    async def test_submit_manual_results_sos_feed_409(self, admin_client: httpx.AsyncClient) -> None:
+        """Submitting results to an SOS feed election returns 409."""
+        payload = {
+            "candidates": [{"name": "Test", "vote_count": 1}],
+        }
+        resp = await admin_client.post(_url(f"/elections/{ELECTION_ID}/results"), json=payload)
+        assert resp.status_code == 409
+
     async def test_get_election_results_empty(self, client: httpx.AsyncClient) -> None:
         """Results endpoint returns 200 with empty data when no results ingested yet."""
         resp = await client.get(_url(f"/elections/{ELECTION_ID}/results"))

--- a/tests/integration/test_api/test_election_api.py
+++ b/tests/integration/test_api/test_election_api.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from voter_api.api.v1.elections import elections_router
 from voter_api.core.dependencies import get_async_session, get_current_user
 from voter_api.models.election import Election, ElectionCountyResult, ElectionResult
+from voter_api.services.election_service import ElectionNotFoundError, ManualResultConflictError
 
 
 def _make_election(**overrides) -> Election:
@@ -141,6 +142,16 @@ def mock_viewer_user():
 
 
 @pytest.fixture
+def mock_analyst_user():
+    user = MagicMock()
+    user.role = "analyst"
+    user.id = "analyst-user-id"
+    user.username = "analyst"
+    user.is_active = True
+    return user
+
+
+@pytest.fixture
 def app(mock_session) -> FastAPI:
     """Minimal FastAPI app with elections router (no auth by default)."""
     app = FastAPI()
@@ -160,6 +171,26 @@ def admin_app(mock_session, mock_admin_user) -> FastAPI:
 
 
 @pytest.fixture
+def viewer_app(mock_session, mock_viewer_user) -> FastAPI:
+    """FastAPI app with viewer auth."""
+    app = FastAPI()
+    app.include_router(elections_router, prefix="/api/v1")
+    app.dependency_overrides[get_async_session] = lambda: mock_session
+    app.dependency_overrides[get_current_user] = lambda: mock_viewer_user
+    return app
+
+
+@pytest.fixture
+def analyst_app(mock_session, mock_analyst_user) -> FastAPI:
+    """FastAPI app with analyst auth."""
+    app = FastAPI()
+    app.include_router(elections_router, prefix="/api/v1")
+    app.dependency_overrides[get_async_session] = lambda: mock_session
+    app.dependency_overrides[get_current_user] = lambda: mock_analyst_user
+    return app
+
+
+@pytest.fixture
 def client(app: FastAPI) -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=app), base_url="https://test")
 
@@ -167,6 +198,16 @@ def client(app: FastAPI) -> AsyncClient:
 @pytest.fixture
 def admin_client(admin_app: FastAPI) -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=admin_app), base_url="https://test")
+
+
+@pytest.fixture
+def viewer_client(viewer_app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=viewer_app), base_url="https://test")
+
+
+@pytest.fixture
+def analyst_client(analyst_app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=analyst_app), base_url="https://test")
 
 
 # --- US1: GET /elections/{id} ---
@@ -967,7 +1008,7 @@ class TestSubmitManualResults:
             precincts_reporting=6,
             candidates=[
                 CandidateResult(
-                    id="andrea-c-cooke",
+                    id="andrea-c-cooke-1",
                     name="Andrea C. Cooke",
                     political_party="",
                     ballot_order=1,
@@ -983,7 +1024,7 @@ class TestSubmitManualResults:
         with patch(
             "voter_api.services.election_service.submit_manual_results",
             new_callable=AsyncMock,
-            return_value=mock_response,
+            return_value=(mock_response, False),
         ):
             resp = await admin_client.post(
                 f"/api/v1/elections/{mock_response.election_id}/results",
@@ -997,11 +1038,64 @@ class TestSubmitManualResults:
         assert data["candidates"][0]["name"] == "Andrea C. Cooke"
 
     @pytest.mark.asyncio
+    async def test_submit_results_update_returns_200(self, admin_client):
+        from voter_api.schemas.election import (
+            CandidateResult,
+            ElectionResultsResponse,
+        )
+
+        mock_response = ElectionResultsResponse(
+            election_id=uuid.uuid4(),
+            election_name="Test",
+            election_date=date(2026, 3, 17),
+            status="active",
+            last_refreshed_at=datetime.now(UTC),
+            precincts_participating=6,
+            precincts_reporting=6,
+            candidates=[
+                CandidateResult(
+                    id="test-1",
+                    name="Test",
+                    political_party="",
+                    ballot_order=1,
+                    vote_count=100,
+                ),
+            ],
+            county_results=[],
+        )
+
+        with patch(
+            "voter_api.services.election_service.submit_manual_results",
+            new_callable=AsyncMock,
+            return_value=(mock_response, True),
+        ):
+            resp = await admin_client.post(
+                f"/api/v1/elections/{mock_response.election_id}/results",
+                json=_MANUAL_RESULTS_BODY,
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_submit_results_sos_feed_returns_409(self, admin_client):
         with patch(
             "voter_api.services.election_service.submit_manual_results",
             new_callable=AsyncMock,
-            side_effect=ValueError("Cannot submit manual results for an SOS feed election."),
+            side_effect=ManualResultConflictError("Cannot submit manual results for a 'sos_feed' election."),
+        ):
+            resp = await admin_client.post(
+                f"/api/v1/elections/{uuid.uuid4()}/results",
+                json=_MANUAL_RESULTS_BODY,
+            )
+
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_submit_results_linked_returns_409(self, admin_client):
+        with patch(
+            "voter_api.services.election_service.submit_manual_results",
+            new_callable=AsyncMock,
+            side_effect=ManualResultConflictError("Cannot submit manual results for a 'linked' election."),
         ):
             resp = await admin_client.post(
                 f"/api/v1/elections/{uuid.uuid4()}/results",
@@ -1015,7 +1109,7 @@ class TestSubmitManualResults:
         with patch(
             "voter_api.services.election_service.submit_manual_results",
             new_callable=AsyncMock,
-            side_effect=ValueError("Election not found."),
+            side_effect=ElectionNotFoundError("Election not found."),
         ):
             resp = await admin_client.post(
                 f"/api/v1/elections/{uuid.uuid4()}/results",
@@ -1033,9 +1127,68 @@ class TestSubmitManualResults:
         assert resp.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_submit_results_viewer_returns_403(self, viewer_client):
+        resp = await viewer_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json=_MANUAL_RESULTS_BODY,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_submit_results_analyst_returns_403(self, analyst_client):
+        resp = await analyst_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json=_MANUAL_RESULTS_BODY,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_submit_results_empty_candidates_returns_422(self, admin_client):
         resp = await admin_client.post(
             f"/api/v1/elections/{uuid.uuid4()}/results",
             json={"candidates": []},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_submit_results_negative_vote_count_returns_422(self, admin_client):
+        resp = await admin_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json={
+                "candidates": [{"name": "Test", "ballot_order": 1, "vote_count": -1}],
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_submit_results_reporting_exceeds_participating_returns_422(self, admin_client):
+        resp = await admin_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json={
+                "precincts_participating": 5,
+                "precincts_reporting": 10,
+                "candidates": [{"name": "Test", "ballot_order": 1, "vote_count": 1}],
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_submit_results_negative_precincts_returns_422(self, admin_client):
+        resp = await admin_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json={
+                "precincts_participating": -1,
+                "candidates": [{"name": "Test", "ballot_order": 1, "vote_count": 1}],
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_submit_results_ballot_order_zero_returns_422(self, admin_client):
+        resp = await admin_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json={
+                "candidates": [{"name": "Test", "ballot_order": 0, "vote_count": 1}],
+            },
         )
         assert resp.status_code == 422

--- a/tests/integration/test_api/test_election_api.py
+++ b/tests/integration/test_api/test_election_api.py
@@ -920,3 +920,122 @@ class TestImportFeed:
             )
 
         assert resp.status_code == 502
+
+
+# --- POST /elections/{id}/results (manual result submission) ---
+
+
+_MANUAL_RESULTS_BODY = {
+    "precincts_participating": 6,
+    "precincts_reporting": 6,
+    "candidates": [
+        {
+            "name": "Andrea C. Cooke",
+            "ballot_order": 1,
+            "vote_count": 458,
+            "group_results": [
+                {"group_name": "Election Day", "vote_count": 271},
+                {"group_name": "Advance Voting", "vote_count": 181},
+                {"group_name": "Absentee by Mail", "vote_count": 6},
+            ],
+        },
+        {
+            "name": "Edward C. Foster",
+            "ballot_order": 2,
+            "vote_count": 167,
+        },
+    ],
+}
+
+
+class TestSubmitManualResults:
+    @pytest.mark.asyncio
+    async def test_submit_results_returns_201(self, admin_client):
+        from voter_api.schemas.election import (
+            CandidateResult,
+            ElectionResultsResponse,
+            VoteMethodResult,
+        )
+
+        mock_response = ElectionResultsResponse(
+            election_id=uuid.uuid4(),
+            election_name="Bibb County Commission District 5",
+            election_date=date(2026, 3, 17),
+            status="active",
+            last_refreshed_at=datetime.now(UTC),
+            precincts_participating=6,
+            precincts_reporting=6,
+            candidates=[
+                CandidateResult(
+                    id="andrea-c-cooke",
+                    name="Andrea C. Cooke",
+                    political_party="",
+                    ballot_order=1,
+                    vote_count=458,
+                    group_results=[
+                        VoteMethodResult(group_name="Election Day", vote_count=271),
+                    ],
+                ),
+            ],
+            county_results=[],
+        )
+
+        with patch(
+            "voter_api.services.election_service.submit_manual_results",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            resp = await admin_client.post(
+                f"/api/v1/elections/{mock_response.election_id}/results",
+                json=_MANUAL_RESULTS_BODY,
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["precincts_reporting"] == 6
+        assert len(data["candidates"]) == 1
+        assert data["candidates"][0]["name"] == "Andrea C. Cooke"
+
+    @pytest.mark.asyncio
+    async def test_submit_results_sos_feed_returns_409(self, admin_client):
+        with patch(
+            "voter_api.services.election_service.submit_manual_results",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Cannot submit manual results for an SOS feed election."),
+        ):
+            resp = await admin_client.post(
+                f"/api/v1/elections/{uuid.uuid4()}/results",
+                json=_MANUAL_RESULTS_BODY,
+            )
+
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_submit_results_not_found_returns_404(self, admin_client):
+        with patch(
+            "voter_api.services.election_service.submit_manual_results",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Election not found."),
+        ):
+            resp = await admin_client.post(
+                f"/api/v1/elections/{uuid.uuid4()}/results",
+                json=_MANUAL_RESULTS_BODY,
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_submit_results_requires_auth(self, client):
+        resp = await client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json=_MANUAL_RESULTS_BODY,
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_submit_results_empty_candidates_returns_422(self, admin_client):
+        resp = await admin_client.post(
+            f"/api/v1/elections/{uuid.uuid4()}/results",
+            json={"candidates": []},
+        )
+        assert resp.status_code == 422

--- a/tests/unit/test_services/test_election_service.py
+++ b/tests/unit/test_services/test_election_service.py
@@ -26,6 +26,8 @@ from voter_api.schemas.election import (
 )
 from voter_api.services.election_service import (
     DuplicateElectionError,
+    ElectionNotFoundError,
+    ManualResultConflictError,
     _ballot_option_to_candidate,
     _transpose_precinct_results,
     build_detail_response,
@@ -39,6 +41,7 @@ from voter_api.services.election_service import (
     persist_ingestion_result,
     refresh_all_active_elections,
     refresh_single_election,
+    submit_manual_results,
     update_election,
 )
 
@@ -1320,3 +1323,161 @@ class TestGetElectionPrecinctResultsGeoJSON:
         ) as mock_lookup:
             await get_election_precinct_results_geojson(session, election.id)
             mock_lookup.assert_awaited_once_with(session, "Houston", ["P01"], {"P01": "Precinct 1"})
+
+
+# --- Manual result submission ---
+
+
+class TestSubmitManualResults:
+    """Unit tests for submit_manual_results service function."""
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_election_not_found_error(self):
+        session = AsyncMock()
+        with (
+            patch(
+                "voter_api.services.election_service.get_election_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(ElectionNotFoundError, match="not found"),
+        ):
+            await submit_manual_results(session, uuid.uuid4(), MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_sos_feed_raises_conflict_error(self):
+        election = _mock_election(source="sos_feed")
+        session = AsyncMock()
+        with (
+            patch(
+                "voter_api.services.election_service.get_election_by_id",
+                new_callable=AsyncMock,
+                return_value=election,
+            ),
+            pytest.raises(ManualResultConflictError, match="sos_feed"),
+        ):
+            await submit_manual_results(session, election.id, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_linked_raises_conflict_error(self):
+        election = _mock_election(source="linked")
+        session = AsyncMock()
+        with (
+            patch(
+                "voter_api.services.election_service.get_election_by_id",
+                new_callable=AsyncMock,
+                return_value=election,
+            ),
+            pytest.raises(ManualResultConflictError, match="linked"),
+        ):
+            await submit_manual_results(session, election.id, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_manual_source_succeeds(self):
+        from voter_api.schemas.election import (
+            ManualCandidateResult,
+            ManualResultSubmitRequest,
+        )
+
+        election = _mock_election(source="manual")
+        request = ManualResultSubmitRequest(
+            precincts_participating=6,
+            precincts_reporting=6,
+            candidates=[
+                ManualCandidateResult(name="John Smith", ballot_order=1, vote_count=100),
+                ManualCandidateResult(name="Jane Doe", ballot_order=2, vote_count=50),
+            ],
+        )
+        session = AsyncMock()
+        # Mock the SELECT ... FOR UPDATE returning no existing row
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+
+        with patch(
+            "voter_api.services.election_service.get_election_by_id",
+            new_callable=AsyncMock,
+            return_value=election,
+        ):
+            result, is_update = await submit_manual_results(session, election.id, request)
+
+        assert not is_update
+        assert result.precincts_reporting == 6
+        assert len(result.candidates) == 2
+        assert result.candidates[0].name == "John Smith"
+        assert result.candidates[0].id == "john-smith-1"
+        assert result.candidates[1].id == "jane-doe-2"
+        session.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_slug_handles_special_characters(self):
+        from voter_api.schemas.election import (
+            ManualCandidateResult,
+            ManualResultSubmitRequest,
+        )
+
+        election = _mock_election(source="manual")
+        request = ManualResultSubmitRequest(
+            candidates=[
+                ManualCandidateResult(
+                    name="O'Brien-Smith, Jr.",
+                    ballot_order=1,
+                    vote_count=10,
+                ),
+            ],
+        )
+        session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+
+        with patch(
+            "voter_api.services.election_service.get_election_by_id",
+            new_callable=AsyncMock,
+            return_value=election,
+        ):
+            result, _ = await submit_manual_results(session, election.id, request)
+
+        # Slug should not contain apostrophes, commas, or dots
+        candidate_id = result.candidates[0].id
+        assert "'" not in candidate_id
+        assert "," not in candidate_id
+        assert candidate_id == "o-brien-smith-jr-1"
+
+    @pytest.mark.asyncio
+    async def test_upsert_updates_existing_row(self):
+        from voter_api.schemas.election import (
+            ManualCandidateResult,
+            ManualResultSubmitRequest,
+        )
+
+        election = _mock_election(source="manual")
+        request = ManualResultSubmitRequest(
+            precincts_participating=10,
+            precincts_reporting=8,
+            candidates=[
+                ManualCandidateResult(name="Test", ballot_order=1, vote_count=50),
+            ],
+        )
+        session = AsyncMock()
+        existing_row = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_row
+        session.execute = AsyncMock(return_value=mock_result)
+        session.commit = AsyncMock()
+
+        with patch(
+            "voter_api.services.election_service.get_election_by_id",
+            new_callable=AsyncMock,
+            return_value=election,
+        ):
+            result, is_update = await submit_manual_results(session, election.id, request)
+
+        assert is_update
+        assert existing_row.precincts_reporting == 8
+        assert existing_row.precincts_participating == 10
+        session.add.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/elections/{id}/results` endpoint for submitting election results to manual/linked elections that aren't sourced from the GA SOS feed
- Results are stored in the same JSONB format as SOS feed data, so all existing read endpoints (results, raw, geojson) render them correctly without changes
- Admin-only with 409 rejection for SOS feed elections and 404 for missing elections

## Motivation

The Bibb County Commission District 5 Special Election (2026-03-17) is not published on the GA SOS website, so automatic feed ingestion can't capture results. The election and candidates already exist in the system with `source=manual`, but there was no API endpoint to submit results.

## Test plan

- [x] 5 integration tests: happy path (201), SOS feed rejection (409), not found (404), auth required (401), empty candidates validation (422)
- [x] 2 E2E smoke tests: submit results to manual election, verify 409 for SOS feed election
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] `uv run pytest tests/integration/test_api/test_election_api.py -v` — all 41 tests pass
- [x] `uv run pytest tests/e2e/ --collect-only` — 191 tests collected (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can submit manual election results (create or update) for manual-source elections with candidate and vote-method breakdowns; responses indicate creation (201) or update (200) and surface conflicts (409) or missing elections (404).
* **Validation**
  * Input validation enforces candidate list constraints and precinct reporting rules.
* **Tests**
  * Added extensive end-to-end, integration, and unit tests covering success, idempotency, RBAC, validation, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->